### PR TITLE
Bitflags and null pointer fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Unlicense"
 keywords = ["audio", "ladspa", "dsp"]
 
 [dependencies]
-bitflags = "0.8.2"
+bitflags = "2.9.1"
 vec_map = "0.7.0"
 libc = "0.2.21"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ladspa"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Noah Weninger <nweninge@ualberta.ca>"]
 description = "An interface for writing LADSPA plugins safely in Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["audio", "ladspa", "dsp"]
 bitflags = "2.9.1"
 vec_map = "0.7.0"
 libc = "0.2.21"
+log = "*"
 
 [lib]
 name = "ladspa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ladspa"
 version = "0.3.4"
-edition = "2018"
+edition = "2021"
 authors = ["Noah Weninger <nweninge@ualberta.ca>"]
 description = "An interface for writing LADSPA plugins safely in Rust."
 documentation = "http://nwoeanhinnogaehr.github.io/ladspa.rs/ladspa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-
 name = "ladspa"
 version = "0.3.4"
+edition = "2018"
 authors = ["Noah Weninger <nweninge@ualberta.ca>"]
 description = "An interface for writing LADSPA plugins safely in Rust."
 documentation = "http://nwoeanhinnogaehr.github.io/ladspa.rs/ladspa"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -198,7 +198,7 @@ unsafe fn drop_descriptor(desc: &mut ladspa_h::Descriptor) {
 // The handle that is given to ladspa.
 struct Handle<'a> {
     descriptor: &'static super::PluginDescriptor,
-    plugin: Box<super::Plugin + Send + 'static>,
+    plugin: Box<dyn super::Plugin + Send + 'static>,
     port_map: VecMap<super::PortConnection<'a>>,
     ports: Vec<&'a super::PortConnection<'a>>,
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -10,7 +10,7 @@ use super::PluginDescriptor;
 use super::get_ladspa_descriptor;
 
 macro_rules! call_user_code {
-    ($code:expr, $name:expr) => {
+    ($code:expr_2021, $name:expr_2021) => {
         match catch_unwind(move || $code) {
             Ok(x) => x,
             Err(_) => {
@@ -96,13 +96,13 @@ static mut DESCRIPTORS: *mut Vec<*mut ladspa_h::Descriptor> =
 // It seems that ladspa_descriptor is deleted during link time optimization unless we
 // call it from somewhere.
 #[allow(dead_code)]
-unsafe fn _lto_workaround() {
+unsafe fn _lto_workaround() { unsafe {
     ladspa_descriptor(0);
-}
+}}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 // Exported so the plugin is recognised by ladspa hosts.
-pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Descriptor {
+pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Descriptor { unsafe {
     if DESCRIPTORS == ptr::null_mut() {
         libc::atexit(global_destruct);
         DESCRIPTORS = mem::transmute(Box::new(Vec::<*mut ladspa_h::Descriptor>::new()));
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Des
         }
         None => ptr::null_mut(),
     }
-}
+}}
 
 extern "C" fn global_destruct() {
     unsafe {
@@ -175,25 +175,25 @@ extern "C" fn global_destruct() {
     }
 }
 
-unsafe fn drop_descriptor(desc: &mut ladspa_h::Descriptor) {
-    CString::from_raw(desc.label);
-    CString::from_raw(desc.name);
-    CString::from_raw(desc.maker);
-    CString::from_raw(desc.copyright);
-    Vec::from_raw_parts(desc.port_descriptors,
+unsafe fn drop_descriptor(desc: &mut ladspa_h::Descriptor) { unsafe {
+    let _ = CString::from_raw(desc.label);
+    let _ = CString::from_raw(desc.name);
+    let _ = CString::from_raw(desc.maker);
+    let _ = CString::from_raw(desc.copyright);
+    let _ = Vec::from_raw_parts(desc.port_descriptors,
                         desc.port_count as usize,
                         desc.port_count as usize);
-    Vec::from_raw_parts(desc.port_names,
+    let _ = Vec::from_raw_parts(desc.port_names,
                         desc.port_count as usize,
                         desc.port_count as usize)
         .iter()
         .map(|&x| CString::from_raw(x))
         .collect::<Vec<_>>();
-    Vec::from_raw_parts(desc.port_range_hints,
+    let _ = Vec::from_raw_parts(desc.port_range_hints,
                         desc.port_count as usize,
                         desc.port_count as usize);
     mem::transmute::<_, Box<PluginDescriptor>>(desc.implementation_data);
-}
+}}
 
 // The handle that is given to ladspa.
 struct Handle<'a> {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -110,19 +110,25 @@ pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Des
     unsafe {
         if DESCRIPTORS.is_null() {
             libc::atexit(global_destruct);
-            DESCRIPTORS = mem::transmute(Box::new(Vec::<*mut ladspa_h::Descriptor>::new()));
+            DESCRIPTORS = mem::transmute::<
+                std::boxed::Box<std::vec::Vec<*mut ladspa_h::Descriptor>>,
+                *mut std::vec::Vec<*mut ladspa_h::Descriptor>,
+            >(Box::new(Vec::<*mut ladspa_h::Descriptor>::new()));
         }
 
         // If it's already been generated, return the cached copy.
         if (index as usize) < (*DESCRIPTORS).len() {
-            return mem::transmute(&*(*DESCRIPTORS)[index as usize]);
+            return &mut *(*DESCRIPTORS)[index as usize] as *mut ladspa_h::Descriptor;
         }
 
         let descriptor = call_user_code!(get_ladspa_descriptor(index), "get_ladspa_descriptor");
 
         match descriptor {
             Some(plugin) => {
-                let desc = mem::transmute(Box::new(ladspa_h::Descriptor {
+                let desc = mem::transmute::<
+                    std::boxed::Box<ladspa_h::Descriptor>,
+                    *mut ladspa_h::Descriptor,
+                >(Box::new(ladspa_h::Descriptor {
                     unique_id: plugin.unique_id as c_ulong,
                     label: CString::new(plugin.label).unwrap().into_raw(),
                     properties: plugin.properties.bits(),
@@ -131,7 +137,7 @@ pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Des
                     copyright: CString::new(plugin.copyright).unwrap().into_raw(),
 
                     port_count: plugin.ports.len() as c_ulong,
-                    port_descriptors: mem::transmute::<_, &mut [i32]>(
+                    port_descriptors: mem::transmute::<std::boxed::Box<[i32]>, &mut [i32]>(
                         plugin
                             .ports
                             .iter()
@@ -140,7 +146,7 @@ pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Des
                             .into_boxed_slice(),
                     )
                     .as_mut_ptr(),
-                    port_names: mem::transmute::<_, &mut [*mut c_char]>(
+                    port_names: mem::transmute::<std::boxed::Box<[*mut i8]>, &mut [*mut c_char]>(
                         plugin
                             .ports
                             .iter()
@@ -149,7 +155,10 @@ pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Des
                             .into_boxed_slice(),
                     )
                     .as_mut_ptr(),
-                    port_range_hints: mem::transmute::<_, &mut [ladspa_h::PortRangeHint]>(
+                    port_range_hints: mem::transmute::<
+                        std::boxed::Box<[ladspa_h::PortRangeHint]>,
+                        &mut [ladspa_h::PortRangeHint],
+                    >(
                         plugin
                             .ports
                             .iter()
@@ -171,7 +180,10 @@ pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Des
                             .into_boxed_slice(),
                     )
                     .as_mut_ptr(),
-                    implementation_data: mem::transmute(Box::new(plugin)),
+                    implementation_data: mem::transmute::<
+                        std::boxed::Box<PluginDescriptor>,
+                        *mut libc::c_void,
+                    >(Box::new(plugin)),
                     instantiate,
                     connect_port,
                     run,
@@ -229,7 +241,7 @@ unsafe fn drop_descriptor(descriptor: &mut ladspa_h::Descriptor) {
             descriptor.port_count as usize,
             descriptor.port_count as usize,
         );
-        mem::transmute::<_, Box<PluginDescriptor>>(descriptor.implementation_data);
+        mem::transmute::<*mut libc::c_void, Box<PluginDescriptor>>(descriptor.implementation_data);
     }
 }
 
@@ -412,6 +424,6 @@ extern "C" fn deactivate(instance: ladspa_h::Handle) {
 
 extern "C" fn cleanup(instance: ladspa_h::Handle) {
     unsafe {
-        mem::transmute::<_, Box<Handle>>(instance);
+        mem::transmute::<*mut libc::c_void, Box<Handle>>(instance);
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -56,7 +56,7 @@ pub mod ladspa_h {
         pub port_range_hints: *mut PortRangeHint,
         pub implementation_data: *mut c_void,
         pub instantiate:
-            extern "C" fn(descriptor: *const Descriptor, sample_rate: c_ulong) -> Handle,
+            extern "C" fn(descriptor: *mut Descriptor, sample_rate: c_ulong) -> Handle,
         pub connect_port: extern "C" fn(instance: Handle, port: c_ulong, data_location: *mut Data),
         pub activate: Option<extern "C" fn(instance: Handle)>,
         pub run: extern "C" fn(instance: Handle, sample_count: c_ulong),
@@ -109,7 +109,7 @@ unsafe fn _lto_workaround() {
 pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Descriptor {
     log::trace!("ladspa_descriptor({})", index);
     unsafe {
-        if DESCRIPTORS == ptr::null_mut() {
+        if DESCRIPTORS.is_null() {
             libc::atexit(global_destruct);
             DESCRIPTORS = mem::transmute(Box::new(Vec::<*mut ladspa_h::Descriptor>::new()));
         }
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Des
         }
 
         let descriptor =
-            call_user_code!(get_ladspa_descriptor(index as u64), "get_ladspa_descriptor");
+            call_user_code!(get_ladspa_descriptor(index), "get_ladspa_descriptor");
 
         match descriptor {
             Some(plugin) => {
@@ -174,10 +174,10 @@ pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Des
                     )
                     .as_mut_ptr(),
                     implementation_data: mem::transmute(Box::new(plugin)),
-                    instantiate: instantiate,
-                    connect_port: connect_port,
-                    run: run,
-                    cleanup: cleanup,
+                    instantiate,
+                    connect_port,
+                    run,
+                    cleanup,
                     run_adding: None,
                     set_run_adding_gain: None,
                     activate: Some(activate),
@@ -198,7 +198,7 @@ extern "C" fn global_destruct() {
     unsafe {
         let descriptors: Box<Vec<*mut ladspa_h::Descriptor>> = mem::transmute(DESCRIPTORS);
         for desc in descriptors.iter() {
-            drop_descriptor(mem::transmute(*desc));
+            drop_descriptor(&mut *(*desc));
         }
     }
 }
@@ -244,7 +244,7 @@ struct Handle<'a> {
 }
 
 extern "C" fn instantiate(
-    descriptor: *const ladspa_h::Descriptor,
+    descriptor: * mut ladspa_h::Descriptor,
     sample_rate: c_ulong,
 ) -> ladspa_h::Handle {
     log::trace!(
@@ -257,11 +257,11 @@ extern "C" fn instantiate(
         return core::ptr::null_mut();
     }
     unsafe {
-        let desc: &mut ladspa_h::Descriptor = mem::transmute(descriptor);
+        let desc: &mut ladspa_h::Descriptor = &mut *descriptor;
 
-        let rust_desc: &super::PluginDescriptor = mem::transmute(desc.implementation_data);
+        let rust_desc: &super::PluginDescriptor = &*(desc.implementation_data as *const PluginDescriptor);
         let rust_plugin = match call_user_code!(
-            Some((rust_desc.new)(rust_desc, sample_rate as u64)),
+            Some((rust_desc.new)(rust_desc, sample_rate)),
             "PluginDescriptor::run"
         ) {
             Some(plug) => plug,
@@ -273,8 +273,8 @@ extern "C" fn instantiate(
         mem::transmute(Box::new(Handle {
             descriptor: rust_desc,
             plugin: rust_plugin,
-            port_map: port_map,
-            ports: ports,
+            port_map,
+            ports,
         }))
     }
 }
@@ -295,7 +295,7 @@ extern "C" fn connect_port(
         return;
     }
     unsafe {
-        let handle: &mut Handle = mem::transmute(instance);
+        let handle: &mut Handle = &mut *(instance as *mut Handle);
 
         let port = handle.descriptor.ports[port_num as usize];
 
@@ -313,22 +313,22 @@ extern "C" fn connect_port(
                 )))
             }
             super::PortDescriptor::ControlInput => {
-                super::PortData::ControlInput(mem::transmute(data_location))
+                super::PortData::ControlInput(&*data_location)
             }
             super::PortDescriptor::ControlOutput => {
-                super::PortData::ControlOutput(RefCell::new(mem::transmute(data_location)))
+                super::PortData::ControlOutput(RefCell::new(&mut *data_location))
             }
             super::PortDescriptor::Invalid => panic!("Invalid port descriptor!"),
         };
 
         let conn = super::PortConnection {
-            port: port,
-            data: data,
+            port,
+            data,
         };
         handle.port_map.insert(port_num as usize, conn);
 
         // Depends on the assumption that ports will be recreated whenever port_map changes
-        let handle_ptr: &mut Handle = mem::transmute(instance);
+        let handle_ptr: &mut Handle = &mut *(instance as *mut Handle);
         if handle.port_map.len() == handle.descriptor.ports.len() {
             handle_ptr.ports = handle.port_map.values().collect();
         }
@@ -346,7 +346,7 @@ extern "C" fn run(instance: ladspa_h::Handle, sample_count: c_ulong) {
         return;
     }
     unsafe {
-        let handle: &mut Handle = mem::transmute(instance);
+        let handle: &mut Handle = &mut *(instance as *mut Handle);
         for (_, port) in handle.port_map.iter_mut() {
             match port.data {
                 super::PortData::AudioOutput(ref mut data) => {
@@ -363,7 +363,7 @@ extern "C" fn run(instance: ladspa_h::Handle, sample_count: c_ulong) {
         let mut handle = AssertUnwindSafe(handle);
         call_user_code!(
             Some({
-                let ref mut handle = *handle;
+                let handle = &mut (*handle);
                 handle.plugin.run(sample_count as usize, &handle.ports)
             }),
             "Plugin::run"
@@ -378,9 +378,12 @@ extern "C" fn activate(instance: ladspa_h::Handle) {
         return;
     }
     unsafe {
-        let handle: &mut Handle = mem::transmute(instance);
+        let handle: &mut Handle = &mut *(instance as *mut Handle);
         let mut handle = AssertUnwindSafe(handle);
-        call_user_code!(Some(handle.plugin.activate()), "Plugin::activate");
+        call_user_code!({
+            handle.plugin.activate();
+            Some(())
+        }, "Plugin::activate");
     }
 }
 extern "C" fn deactivate(instance: ladspa_h::Handle) {
@@ -390,9 +393,12 @@ extern "C" fn deactivate(instance: ladspa_h::Handle) {
         return;
     }
     unsafe {
-        let handle: &mut Handle = mem::transmute(instance);
+        let handle: &mut Handle = &mut *(instance as *mut Handle);
         let mut handle = AssertUnwindSafe(handle);
-        call_user_code!(Some(handle.plugin.deactivate()), "Plugin::deactivate");
+        call_user_code!({
+            handle.plugin.deactivate();
+            Some(())
+        }, "Plugin::deactivate");
     }
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -55,8 +55,7 @@ pub mod ladspa_h {
         pub port_names: *mut *mut c_char,
         pub port_range_hints: *mut PortRangeHint,
         pub implementation_data: *mut c_void,
-        pub instantiate:
-            extern "C" fn(descriptor: *mut Descriptor, sample_rate: c_ulong) -> Handle,
+        pub instantiate: extern "C" fn(descriptor: *mut Descriptor, sample_rate: c_ulong) -> Handle,
         pub connect_port: extern "C" fn(instance: Handle, port: c_ulong, data_location: *mut Data),
         pub activate: Option<extern "C" fn(instance: Handle)>,
         pub run: extern "C" fn(instance: Handle, sample_count: c_ulong),
@@ -119,8 +118,7 @@ pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Des
             return mem::transmute(&*(*DESCRIPTORS)[index as usize]);
         }
 
-        let descriptor =
-            call_user_code!(get_ladspa_descriptor(index), "get_ladspa_descriptor");
+        let descriptor = call_user_code!(get_ladspa_descriptor(index), "get_ladspa_descriptor");
 
         match descriptor {
             Some(plugin) => {
@@ -244,7 +242,7 @@ struct Handle<'a> {
 }
 
 extern "C" fn instantiate(
-    descriptor: * mut ladspa_h::Descriptor,
+    descriptor: *mut ladspa_h::Descriptor,
     sample_rate: c_ulong,
 ) -> ladspa_h::Handle {
     log::trace!(
@@ -259,7 +257,8 @@ extern "C" fn instantiate(
     unsafe {
         let desc: &mut ladspa_h::Descriptor = &mut *descriptor;
 
-        let rust_desc: &super::PluginDescriptor = &*(desc.implementation_data as *const PluginDescriptor);
+        let rust_desc: &super::PluginDescriptor =
+            &*(desc.implementation_data as *const PluginDescriptor);
         let rust_plugin = match call_user_code!(
             Some((rust_desc.new)(rust_desc, sample_rate)),
             "PluginDescriptor::run"
@@ -312,19 +311,14 @@ extern "C" fn connect_port(
                     0,
                 )))
             }
-            super::PortDescriptor::ControlInput => {
-                super::PortData::ControlInput(&*data_location)
-            }
+            super::PortDescriptor::ControlInput => super::PortData::ControlInput(&*data_location),
             super::PortDescriptor::ControlOutput => {
                 super::PortData::ControlOutput(RefCell::new(&mut *data_location))
             }
             super::PortDescriptor::Invalid => panic!("Invalid port descriptor!"),
         };
 
-        let conn = super::PortConnection {
-            port,
-            data,
-        };
+        let conn = super::PortConnection { port, data };
         handle.port_map.insert(port_num as usize, conn);
 
         // Depends on the assumption that ports will be recreated whenever port_map changes
@@ -362,10 +356,13 @@ extern "C" fn run(instance: ladspa_h::Handle, sample_count: c_ulong) {
         }
         let mut handle = AssertUnwindSafe(handle);
         call_user_code!(
-            Some({
-                let handle = &mut (*handle);
-                handle.plugin.run(sample_count as usize, &handle.ports)
-            }),
+            {
+                {
+                    let handle = &mut (*handle);
+                    handle.plugin.run(sample_count as usize, &handle.ports)
+                };
+                Some(())
+            },
             "Plugin::run"
         );
     }
@@ -380,10 +377,13 @@ extern "C" fn activate(instance: ladspa_h::Handle) {
     unsafe {
         let handle: &mut Handle = &mut *(instance as *mut Handle);
         let mut handle = AssertUnwindSafe(handle);
-        call_user_code!({
-            handle.plugin.activate();
-            Some(())
-        }, "Plugin::activate");
+        call_user_code!(
+            {
+                handle.plugin.activate();
+                Some(())
+            },
+            "Plugin::activate"
+        );
     }
 }
 extern "C" fn deactivate(instance: ladspa_h::Handle) {
@@ -395,10 +395,13 @@ extern "C" fn deactivate(instance: ladspa_h::Handle) {
     unsafe {
         let handle: &mut Handle = &mut *(instance as *mut Handle);
         let mut handle = AssertUnwindSafe(handle);
-        call_user_code!({
-            handle.plugin.deactivate();
-            Some(())
-        }, "Plugin::deactivate");
+        call_user_code!(
+            {
+                handle.plugin.deactivate();
+                Some(())
+            },
+            "Plugin::deactivate"
+        );
     }
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,13 +1,14 @@
-use std::{mem, ptr};
-use libc::{self, c_char, c_ulong};
-use std::slice;
 use std::cell::RefCell;
-use vec_map::VecMap;
 use std::ffi::CString;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::slice;
+use std::{mem, ptr};
 
-use super::PluginDescriptor;
+use libc::{self, c_char, c_ulong};
+use vec_map::VecMap;
+
 use super::get_ladspa_descriptor;
+use super::PluginDescriptor;
 
 macro_rules! call_user_code {
     ($code:expr_2021, $name:expr_2021) => {
@@ -18,12 +19,12 @@ macro_rules! call_user_code {
                 None
             }
         }
-    }
+    };
 }
 
 // essentially ladspa.h API translated to rust.
 pub mod ladspa_h {
-    use libc::{c_void, c_char, c_int, c_ulong, c_float};
+    use libc::{c_char, c_float, c_int, c_ulong, c_void};
 
     pub type Data = c_float;
     pub type Properties = c_int;
@@ -54,7 +55,8 @@ pub mod ladspa_h {
         pub port_names: *mut *mut c_char,
         pub port_range_hints: *mut PortRangeHint,
         pub implementation_data: *mut c_void,
-        pub instantiate: extern "C" fn(descriptor: *const Descriptor, sample_rate: c_ulong) -> Handle,
+        pub instantiate:
+            extern "C" fn(descriptor: *const Descriptor, sample_rate: c_ulong) -> Handle,
         pub connect_port: extern "C" fn(instance: Handle, port: c_ulong, data_location: *mut Data),
         pub activate: Option<extern "C" fn(instance: Handle)>,
         pub run: extern "C" fn(instance: Handle, sample_count: c_ulong),
@@ -96,104 +98,142 @@ static mut DESCRIPTORS: *mut Vec<*mut ladspa_h::Descriptor> =
 // It seems that ladspa_descriptor is deleted during link time optimization unless we
 // call it from somewhere.
 #[allow(dead_code)]
-unsafe fn _lto_workaround() { unsafe {
-    ladspa_descriptor(0);
-}}
+unsafe fn _lto_workaround() {
+    unsafe {
+        ladspa_descriptor(0);
+    }
+}
 
 #[unsafe(no_mangle)]
 // Exported so the plugin is recognised by ladspa hosts.
-pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Descriptor { unsafe {
-    if DESCRIPTORS == ptr::null_mut() {
-        libc::atexit(global_destruct);
-        DESCRIPTORS = mem::transmute(Box::new(Vec::<*mut ladspa_h::Descriptor>::new()));
-    }
-
-    // If it's already been generated, return the cached copy.
-    if (index as usize) < (*DESCRIPTORS).len() {
-        return mem::transmute(&*(*DESCRIPTORS)[index as usize]);
-    }
-
-    let descriptor = call_user_code!(get_ladspa_descriptor(index as u64), "get_ladspa_descriptor");
-
-    match descriptor {
-        Some(plugin) => {
-            let desc = mem::transmute(Box::new(ladspa_h::Descriptor {
-                unique_id: plugin.unique_id as c_ulong,
-                label: CString::new(plugin.label).unwrap().into_raw(),
-                properties: plugin.properties.bits(),
-                name: CString::new(plugin.name).unwrap().into_raw(),
-                maker: CString::new(plugin.maker).unwrap().into_raw(),
-                copyright: CString::new(plugin.copyright).unwrap().into_raw(),
-
-                port_count: plugin.ports.len() as c_ulong,
-                port_descriptors: mem::transmute::<_, &mut [i32]>(
-                    plugin.ports.iter().map(|port|
-                                            port.desc as i32
-                                           ).collect::<Vec<_>>().into_boxed_slice()).as_mut_ptr(),
-                port_names: mem::transmute::<_, &mut [*mut c_char]>(
-                    plugin.ports.iter().map(|port|
-                                            CString::new(port.name).unwrap().into_raw()
-                                           ).collect::<Vec<_>>().into_boxed_slice()).as_mut_ptr(),
-                port_range_hints: mem::transmute::<_, &mut [ladspa_h::PortRangeHint]>(
-                    plugin.ports.iter().map(|port|
-                                            ladspa_h::PortRangeHint {
-                                                hint_descriptor: port.hint.map(|x| x.bits()).unwrap_or(0) |
-                                                    port.default.map(|x| x as i32).unwrap_or(0) |
-                                                    port.lower_bound.map(|_| ladspa_h::HINT_BOUNDED_BELOW)
-                                                    .unwrap_or(0) |
-                                                    port.upper_bound.map(|_| ladspa_h::HINT_BOUNDED_ABOVE)
-                                                    .unwrap_or(0),
-                                                 lower_bound: port.lower_bound.unwrap_or(0_f32),
-                                                 upper_bound: port.upper_bound.unwrap_or(0_f32),
-                                            }
-                                         ).collect::<Vec<_>>().into_boxed_slice()).as_mut_ptr(),
-                implementation_data: mem::transmute(Box::new(plugin)),
-                instantiate: instantiate,
-                connect_port: connect_port,
-                run: run,
-                cleanup: cleanup,
-                run_adding: None,
-                set_run_adding_gain: None,
-                activate: Some(activate),
-                deactivate: Some(deactivate),
-            }));
-
-            // store in global descriptor table
-            (*DESCRIPTORS).push(desc);
-            desc
+pub unsafe extern "C" fn ladspa_descriptor(index: c_ulong) -> *mut ladspa_h::Descriptor {
+    log::trace!("ladspa_descriptor({})", index);
+    unsafe {
+        if DESCRIPTORS == ptr::null_mut() {
+            libc::atexit(global_destruct);
+            DESCRIPTORS = mem::transmute(Box::new(Vec::<*mut ladspa_h::Descriptor>::new()));
         }
-        None => ptr::null_mut(),
+
+        // If it's already been generated, return the cached copy.
+        if (index as usize) < (*DESCRIPTORS).len() {
+            return mem::transmute(&*(*DESCRIPTORS)[index as usize]);
+        }
+
+        let descriptor =
+            call_user_code!(get_ladspa_descriptor(index as u64), "get_ladspa_descriptor");
+
+        match descriptor {
+            Some(plugin) => {
+                let desc = mem::transmute(Box::new(ladspa_h::Descriptor {
+                    unique_id: plugin.unique_id as c_ulong,
+                    label: CString::new(plugin.label).unwrap().into_raw(),
+                    properties: plugin.properties.bits(),
+                    name: CString::new(plugin.name).unwrap().into_raw(),
+                    maker: CString::new(plugin.maker).unwrap().into_raw(),
+                    copyright: CString::new(plugin.copyright).unwrap().into_raw(),
+
+                    port_count: plugin.ports.len() as c_ulong,
+                    port_descriptors: mem::transmute::<_, &mut [i32]>(
+                        plugin
+                            .ports
+                            .iter()
+                            .map(|port| port.desc as i32)
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice(),
+                    )
+                    .as_mut_ptr(),
+                    port_names: mem::transmute::<_, &mut [*mut c_char]>(
+                        plugin
+                            .ports
+                            .iter()
+                            .map(|port| CString::new(port.name).unwrap().into_raw())
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice(),
+                    )
+                    .as_mut_ptr(),
+                    port_range_hints: mem::transmute::<_, &mut [ladspa_h::PortRangeHint]>(
+                        plugin
+                            .ports
+                            .iter()
+                            .map(|port| ladspa_h::PortRangeHint {
+                                hint_descriptor: port.hint.map(|x| x.bits()).unwrap_or(0)
+                                    | port.default.map(|x| x as i32).unwrap_or(0)
+                                    | port
+                                        .lower_bound
+                                        .map(|_| ladspa_h::HINT_BOUNDED_BELOW)
+                                        .unwrap_or(0)
+                                    | port
+                                        .upper_bound
+                                        .map(|_| ladspa_h::HINT_BOUNDED_ABOVE)
+                                        .unwrap_or(0),
+                                lower_bound: port.lower_bound.unwrap_or(0_f32),
+                                upper_bound: port.upper_bound.unwrap_or(0_f32),
+                            })
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice(),
+                    )
+                    .as_mut_ptr(),
+                    implementation_data: mem::transmute(Box::new(plugin)),
+                    instantiate: instantiate,
+                    connect_port: connect_port,
+                    run: run,
+                    cleanup: cleanup,
+                    run_adding: None,
+                    set_run_adding_gain: None,
+                    activate: Some(activate),
+                    deactivate: Some(deactivate),
+                }));
+
+                // store in global descriptor table
+                (*DESCRIPTORS).push(desc);
+                desc
+            }
+            None => ptr::null_mut(),
+        }
     }
-}}
+}
 
 extern "C" fn global_destruct() {
+    log::trace!("global_destruct()");
     unsafe {
-        let descs: Box<Vec<*mut ladspa_h::Descriptor>> = mem::transmute(DESCRIPTORS);
-        for desc in descs.iter() {
+        let descriptors: Box<Vec<*mut ladspa_h::Descriptor>> = mem::transmute(DESCRIPTORS);
+        for desc in descriptors.iter() {
             drop_descriptor(mem::transmute(*desc));
         }
     }
 }
 
-unsafe fn drop_descriptor(desc: &mut ladspa_h::Descriptor) { unsafe {
-    let _ = CString::from_raw(desc.label);
-    let _ = CString::from_raw(desc.name);
-    let _ = CString::from_raw(desc.maker);
-    let _ = CString::from_raw(desc.copyright);
-    let _ = Vec::from_raw_parts(desc.port_descriptors,
-                        desc.port_count as usize,
-                        desc.port_count as usize);
-    let _ = Vec::from_raw_parts(desc.port_names,
-                        desc.port_count as usize,
-                        desc.port_count as usize)
+unsafe fn drop_descriptor(descriptor: &mut ladspa_h::Descriptor) {
+    log::trace!(
+        "drop_descriptor(0x{:08x})",
+        descriptor as *mut ladspa_h::Descriptor as usize
+    );
+    unsafe {
+        let _ = CString::from_raw(descriptor.label);
+        let _ = CString::from_raw(descriptor.name);
+        let _ = CString::from_raw(descriptor.maker);
+        let _ = CString::from_raw(descriptor.copyright);
+        let _ = Vec::from_raw_parts(
+            descriptor.port_descriptors,
+            descriptor.port_count as usize,
+            descriptor.port_count as usize,
+        );
+        let _ = Vec::from_raw_parts(
+            descriptor.port_names,
+            descriptor.port_count as usize,
+            descriptor.port_count as usize,
+        )
         .iter()
         .map(|&x| CString::from_raw(x))
         .collect::<Vec<_>>();
-    let _ = Vec::from_raw_parts(desc.port_range_hints,
-                        desc.port_count as usize,
-                        desc.port_count as usize);
-    mem::transmute::<_, Box<PluginDescriptor>>(desc.implementation_data);
-}}
+        let _ = Vec::from_raw_parts(
+            descriptor.port_range_hints,
+            descriptor.port_count as usize,
+            descriptor.port_count as usize,
+        );
+        mem::transmute::<_, Box<PluginDescriptor>>(descriptor.implementation_data);
+    }
+}
 
 // The handle that is given to ladspa.
 struct Handle<'a> {
@@ -203,15 +243,27 @@ struct Handle<'a> {
     ports: Vec<&'a super::PortConnection<'a>>,
 }
 
-extern "C" fn instantiate(descriptor: *const ladspa_h::Descriptor,
-                          sample_rate: c_ulong)
-                          -> ladspa_h::Handle {
+extern "C" fn instantiate(
+    descriptor: *const ladspa_h::Descriptor,
+    sample_rate: c_ulong,
+) -> ladspa_h::Handle {
+    log::trace!(
+        "instantiate(0x{:08x}, {})",
+        descriptor as usize,
+        sample_rate
+    );
+    if descriptor.is_null() {
+        log::error!("Couldn't instantiate: descriptor was NULL");
+        return core::ptr::null_mut();
+    }
     unsafe {
         let desc: &mut ladspa_h::Descriptor = mem::transmute(descriptor);
 
         let rust_desc: &super::PluginDescriptor = mem::transmute(desc.implementation_data);
-        let rust_plugin = match call_user_code!(Some((rust_desc.new)(rust_desc, sample_rate as u64)),
-                                                "PluginDescriptor::run") {
+        let rust_plugin = match call_user_code!(
+            Some((rust_desc.new)(rust_desc, sample_rate as u64)),
+            "PluginDescriptor::run"
+        ) {
             Some(plug) => plug,
             None => return ptr::null_mut(),
         };
@@ -227,9 +279,21 @@ extern "C" fn instantiate(descriptor: *const ladspa_h::Descriptor,
     }
 }
 
-extern "C" fn connect_port(instance: ladspa_h::Handle,
-                           port_num: c_ulong,
-                           data_location: *mut ladspa_h::Data) {
+extern "C" fn connect_port(
+    instance: ladspa_h::Handle,
+    port_num: c_ulong,
+    data_location: *mut ladspa_h::Data,
+) {
+    log::trace!(
+        "connect_port({}, {}, 0x{:08x})",
+        instance as usize,
+        port_num,
+        data_location as usize
+    );
+    if instance.is_null() {
+        log::error!("Could not connect port: instance was NULL");
+        return;
+    }
     unsafe {
         let handle: &mut Handle = mem::transmute(instance);
 
@@ -243,8 +307,10 @@ extern "C" fn connect_port(instance: ladspa_h::Handle,
             }
             super::PortDescriptor::AudioOutput => {
                 // Same here.
-                super::PortData::AudioOutput(RefCell::new(slice::from_raw_parts_mut(data_location,
-                                                                                    0)))
+                super::PortData::AudioOutput(RefCell::new(slice::from_raw_parts_mut(
+                    data_location,
+                    0,
+                )))
             }
             super::PortDescriptor::ControlInput => {
                 super::PortData::ControlInput(mem::transmute(data_location))
@@ -270,6 +336,15 @@ extern "C" fn connect_port(instance: ladspa_h::Handle,
 }
 
 extern "C" fn run(instance: ladspa_h::Handle, sample_count: c_ulong) {
+    log::trace!(
+        "run({}, {})",
+        instance as *mut ladspa_h::Handle as usize,
+        sample_count
+    );
+    if instance.is_null() {
+        log::error!("Could not run: instance was NULL");
+        return;
+    }
     unsafe {
         let handle: &mut Handle = mem::transmute(instance);
         for (_, port) in handle.port_map.iter_mut() {
@@ -286,15 +361,22 @@ extern "C" fn run(instance: ladspa_h::Handle, sample_count: c_ulong) {
             }
         }
         let mut handle = AssertUnwindSafe(handle);
-        call_user_code!(Some({
-                            let ref mut handle = *handle;
-                            handle.plugin.run(sample_count as usize, &handle.ports)
-                        }),
-                        "Plugin::run");
+        call_user_code!(
+            Some({
+                let ref mut handle = *handle;
+                handle.plugin.run(sample_count as usize, &handle.ports)
+            }),
+            "Plugin::run"
+        );
     }
 }
 
 extern "C" fn activate(instance: ladspa_h::Handle) {
+    log::trace!("activate({})", instance as *mut ladspa_h::Handle as usize);
+    if instance.is_null() {
+        log::error!("Could not activate: instance was NULL");
+        return;
+    }
     unsafe {
         let handle: &mut Handle = mem::transmute(instance);
         let mut handle = AssertUnwindSafe(handle);
@@ -302,6 +384,11 @@ extern "C" fn activate(instance: ladspa_h::Handle) {
     }
 }
 extern "C" fn deactivate(instance: ladspa_h::Handle) {
+    log::trace!("deactivate({})", instance as *mut ladspa_h::Handle as usize);
+    if instance.is_null() {
+        log::error!("Could not deactivate: instance was NULL");
+        return;
+    }
     unsafe {
         let handle: &mut Handle = mem::transmute(instance);
         let mut handle = AssertUnwindSafe(handle);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ use std::cell::{RefCell, RefMut};
 use std::default::Default;
 
 #[allow(improper_ctypes)]
-extern {
+unsafe extern "C" {
     /**
      * Your plugin must implement this function.
      * ```get_ladspa_descriptor``` returns a description of a supported plugin for a given plugin
@@ -155,24 +155,25 @@ bitflags!(
     use of the port and may be completely ignored by the host. For audio ports, use ```CONTROL_HINT_NONE```.
     To attach multiple properties, bitwise-or them together.
     See documentation for the constants beginning with HINT_ for the more information."]
-    pub flags ControlHint: i32 {
+    #[derive(Copy, Clone)]
+    pub struct ControlHint: i32 {
         #[doc="Indicates that this is a toggled port. Toggled ports may only have default values
         of zero or one, although the host may send any value, where <= 0 is false and > 0 is true."]
-        const HINT_TOGGLED = crate::ffi::ladspa_h::HINT_TOGGLED,
+        const HINT_TOGGLED = crate::ffi::ladspa_h::HINT_TOGGLED;
 
         #[doc="Indicates that all values related to the port will be multiplied by the sample rate by
         the host before passing them to your plugin. This includes the lower and upper bounds. If you
         want an upper bound of 22050 with this property and a sample rate of 44100, set the upper bound
         to 0.5"]
-        const HINT_SAMPLE_RATE = crate::ffi::ladspa_h::HINT_SAMPLE_RATE,
+        const HINT_SAMPLE_RATE = crate::ffi::ladspa_h::HINT_SAMPLE_RATE;
 
         #[doc="Indicates that the data passed through this port would be better represented on a
         logarithmic scale"]
-        const HINT_LOGARITHMIC = crate::ffi::ladspa_h::HINT_LOGARITHMIC,
+        const HINT_LOGARITHMIC = crate::ffi::ladspa_h::HINT_LOGARITHMIC;
 
         #[doc="Indicates that the data passed through this port should be represented as integers. Bounds
         may be interpreted exclusively depending on the host"]
-        const HINT_INTEGER = crate::ffi::ladspa_h::HINT_INTEGER,
+        const HINT_INTEGER = crate::ffi::ladspa_h::HINT_INTEGER;
     }
 );
 
@@ -278,20 +279,20 @@ bitflags!(
     To attach multiple properties, bitwise-or them together, for example
     ```PROP_REALTIME | PROP_INPLACE_BROKEN```.
     See documentation for the constants beginning with PROP_ for the more information."]
-    pub flags Properties: i32 {
+    pub struct Properties: i32 {
 
         #[doc="No properties."]
-        const PROP_NONE = 0,
+        const PROP_NONE = 0;
 
         #[doc="Indicates that the plugin has a realtime dependency so it's output may not be cached."]
-        const PROP_REALTIME = crate::ffi::ladspa_h::PROPERTY_REALTIME,
+        const PROP_REALTIME = crate::ffi::ladspa_h::PROPERTY_REALTIME;
 
         #[doc="Indicates that the plugin will not function correctly if the input and output audio
         data has the same memory location. This could be an issue if you copy input to output
         then refer back to previous values of the input as they will be overwritten. It is
         recommended that you avoid using this flag if possible as it can decrease the speed of
         the plugin."]
-        const PROP_INPLACE_BROKEN = crate::ffi::ladspa_h::PROPERTY_INPLACE_BROKEN,
+        const PROP_INPLACE_BROKEN = crate::ffi::ladspa_h::PROPERTY_INPLACE_BROKEN;
 
         #[doc="Indicates that the plugin is capable of running not only in a conventional host but
         also in a 'hard real-time' environment. To qualify for this the plugin must
@@ -316,7 +317,7 @@ bitflags!(
         may not depend on input signals or plugin state. The host is left
         the responsibility to perform timings to estimate upper bounds for
         A and B."]
-        const PROP_HARD_REALTIME_CAPABLE = crate::ffi::ladspa_h::PROPERTY_HARD_RT_CAPABLE,
+        const PROP_HARD_REALTIME_CAPABLE = crate::ffi::ladspa_h::PROPERTY_HARD_RT_CAPABLE;
     }
 );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,19 +35,19 @@
  */
 
 extern crate libc;
-#[macro_use] extern crate bitflags;
+#[macro_use]
+extern crate bitflags;
 extern crate vec_map;
 
 #[doc(hidden)]
 pub mod ffi;
 
-use crate::ffi::ladspa_h;
+use std::cell::{RefCell, RefMut};
+use std::default::Default;
 
 #[doc(hidden)]
 pub use crate::ffi::ladspa_descriptor;
-
-use std::cell::{RefCell, RefMut};
-use std::default::Default;
+use crate::ffi::ladspa_h;
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
@@ -230,7 +230,7 @@ pub enum PortData<'a> {
     ControlOutput(RefCell<&'a mut Data>),
 }
 
-unsafe impl<'a> Sync for PortData<'a> { }
+unsafe impl<'a> Sync for PortData<'a> {}
 
 impl<'a> PortConnection<'a> {
     /// Returns a slice pointing to the internal data of an audio input port. Panics if this port
@@ -327,11 +327,11 @@ pub trait Plugin {
     /// The plugin instance must reset all state information dependent
     /// on the history of the plugin instance here.
     /// Will be called before `run` is called for the first time.
-    fn activate(&mut self) { }
+    fn activate(&mut self) {}
 
     /// Runs the plugin on a number of samples, given the connected ports.
     fn run<'a>(&mut self, sample_count: usize, ports: &[&'a PortConnection<'a>]);
 
     /// Indicates the plugin is no longer live.
-    fn deactivate(&mut self) { }
+    fn deactivate(&mut self) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,6 @@ pub enum PortDescriptor {
     ControlOutput = (ladspa_h::PORT_CONTROL | ladspa_h::PORT_OUTPUT) as isize,
 }
 
-
 bitflags!(
     #[doc="Represents the special properties a control port may hold. These are merely hints as to the
     use of the port and may be completely ignored by the host. For audio ports, use ```CONTROL_HINT_NONE```.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub struct PluginDescriptor {
     /// than here. This should just return a basic instance, ready to be activated.
     /// If your plugin has no internal state, you may optionally not implement ```Plugin::activate```
     /// and do everything here.
-    pub new: fn(desc: &PluginDescriptor, sample_rate: u64) -> Box<Plugin + Send>,
+    pub new: fn(desc: &PluginDescriptor, sample_rate: u64) -> Box<dyn Plugin + Send>,
 }
 
 #[derive(Copy, Clone, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,10 @@ extern crate vec_map;
 #[doc(hidden)]
 pub mod ffi;
 
-use ffi::ladspa_h;
+use crate::ffi::ladspa_h;
 
 #[doc(hidden)]
-pub use ffi::ladspa_descriptor;
+pub use crate::ffi::ladspa_descriptor;
 
 use std::cell::{RefCell, RefMut};
 use std::default::Default;
@@ -158,21 +158,21 @@ bitflags!(
     pub flags ControlHint: i32 {
         #[doc="Indicates that this is a toggled port. Toggled ports may only have default values
         of zero or one, although the host may send any value, where <= 0 is false and > 0 is true."]
-        const HINT_TOGGLED = ::ffi::ladspa_h::HINT_TOGGLED,
+        const HINT_TOGGLED = crate::ffi::ladspa_h::HINT_TOGGLED,
 
         #[doc="Indicates that all values related to the port will be multiplied by the sample rate by
         the host before passing them to your plugin. This includes the lower and upper bounds. If you
         want an upper bound of 22050 with this property and a sample rate of 44100, set the upper bound
         to 0.5"]
-        const HINT_SAMPLE_RATE = ::ffi::ladspa_h::HINT_SAMPLE_RATE,
+        const HINT_SAMPLE_RATE = crate::ffi::ladspa_h::HINT_SAMPLE_RATE,
 
         #[doc="Indicates that the data passed through this port would be better represented on a
         logarithmic scale"]
-        const HINT_LOGARITHMIC = ::ffi::ladspa_h::HINT_LOGARITHMIC,
+        const HINT_LOGARITHMIC = crate::ffi::ladspa_h::HINT_LOGARITHMIC,
 
         #[doc="Indicates that the data passed through this port should be represented as integers. Bounds
         may be interpreted exclusively depending on the host"]
-        const HINT_INTEGER = ::ffi::ladspa_h::HINT_INTEGER,
+        const HINT_INTEGER = crate::ffi::ladspa_h::HINT_INTEGER,
     }
 );
 
@@ -284,14 +284,14 @@ bitflags!(
         const PROP_NONE = 0,
 
         #[doc="Indicates that the plugin has a realtime dependency so it's output may not be cached."]
-        const PROP_REALTIME = ::ffi::ladspa_h::PROPERTY_REALTIME,
+        const PROP_REALTIME = crate::ffi::ladspa_h::PROPERTY_REALTIME,
 
         #[doc="Indicates that the plugin will not function correctly if the input and output audio
         data has the same memory location. This could be an issue if you copy input to output
         then refer back to previous values of the input as they will be overwritten. It is
         recommended that you avoid using this flag if possible as it can decrease the speed of
         the plugin."]
-        const PROP_INPLACE_BROKEN = ::ffi::ladspa_h::PROPERTY_INPLACE_BROKEN,
+        const PROP_INPLACE_BROKEN = crate::ffi::ladspa_h::PROPERTY_INPLACE_BROKEN,
 
         #[doc="Indicates that the plugin is capable of running not only in a conventional host but
         also in a 'hard real-time' environment. To qualify for this the plugin must
@@ -316,7 +316,7 @@ bitflags!(
         may not depend on input signals or plugin state. The host is left
         the responsibility to perform timings to estimate upper bounds for
         A and B."]
-        const PROP_HARD_REALTIME_CAPABLE = ::ffi::ladspa_h::PROPERTY_HARD_RT_CAPABLE,
+        const PROP_HARD_REALTIME_CAPABLE = crate::ffi::ladspa_h::PROPERTY_HARD_RT_CAPABLE,
     }
 );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,9 @@ pub struct Port {
 
 #[derive(Copy, Clone)]
 /// Represents the 4 types of ports: audio or control, input or output.
+#[derive(Default)]
 pub enum PortDescriptor {
+    #[default]
     Invalid = 0,
     AudioInput = (ladspa_h::PORT_AUDIO | ladspa_h::PORT_INPUT) as isize,
     AudioOutput = (ladspa_h::PORT_AUDIO | ladspa_h::PORT_OUTPUT) as isize,
@@ -144,11 +146,6 @@ pub enum PortDescriptor {
     ControlOutput = (ladspa_h::PORT_CONTROL | ladspa_h::PORT_OUTPUT) as isize,
 }
 
-impl Default for PortDescriptor {
-    fn default() -> PortDescriptor {
-        PortDescriptor::Invalid
-    }
-}
 
 bitflags!(
     #[doc="Represents the special properties a control port may hold. These are merely hints as to the
@@ -236,7 +233,7 @@ impl<'a> PortConnection<'a> {
     /// Returns a slice pointing to the internal data of an audio input port. Panics if this port
     /// is not an ```AudioIn``` port.
     pub fn unwrap_audio(&'a self) -> &'a [Data] {
-        if let PortData::AudioInput(ref data) = self.data {
+        if let PortData::AudioInput(data) = self.data {
             data
         } else {
             panic!("PortConnection::unwrap_audio called on a non audio input port!")


### PR DESCRIPTION
This updates `bitflags` to version 2, since `bitflags 0.8` will stop working in a future version of the compiler.

It also updates to 2024 edition, and fixes several soundness bugs that cropped up.

Additionally, this now passes `cargo clippy`

This closes #4 and #5